### PR TITLE
Fix: only_platform circular argument reference

### DIFF
--- a/atomic_red_team/atomic_red_team.rb
+++ b/atomic_red_team/atomic_red_team.rb
@@ -49,7 +49,7 @@ class AtomicRedTeam
   # techniques that already have one or more Atomic Red Team tests, or the create page for
   # techniques that have no existing tests for the given OS.
   #
-  def github_link_to_technique(technique, include_identifier: false, only_platform: only_platform)
+  def github_link_to_technique(technique, include_identifier: false, only_platform: self.only_platform)
     technique_identifier = ATTACK_API.technique_identifier_for_technique(technique).upcase
     link_display = "#{"#{technique_identifier.upcase} " if include_identifier}#{technique['name']}"
     yaml_file = "#{ATOMICS_DIRECTORY}/#{technique_identifier}/#{technique_identifier}.yaml"


### PR DESCRIPTION
Remove a circular argument reference of only_platform, which was causing scripts in ./bin/ to error out when using Ruby version 2.7.

**Details:**
A circular argument reference was preventing scripts in ./bin/ from running successfully on my version of ruby.

```
[billy@art atomic-red-team]$ ruby --version
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]

[billy@art atomic-red-team]$ ./bin/validate-atomics.rb 
Traceback (most recent call last):
	2: from ./bin/validate-atomics.rb:4:in `<main>'
	1: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': /home/billy/Projects/atomic-red-team/atomic_red_team/atomic_red_team.rb:52: circular argument reference - only_platform (SyntaxError)
```

**Testing:**
I tested the change on Arch Linux with Ruby versions:
2.3
2.4
2.7

**Associated Issues:**
None.